### PR TITLE
Made barcode generator work for iOS 5/6

### DIFF
--- a/RSBarcodes.podspec
+++ b/RSBarcodes.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/yeahdongcn/RSBarcodes"
   s.license      = { :type => 'MIT', :file => 'LICENSE.md' }
   s.author       = { "R0CKSTAR" => "yeahdongcn@gmail.com", "张玺" => "zhangxi_1989@sina.com" }
-  s.platform     = :ios, '7.0'
+  s.platform     = :ios, '5.1'
   s.source       = { :git => 'https://github.com/yeahdongcn/RSBarcodes.git', :tag => "#{s.version}" }
   s.source_files = 'RSBarcodes/*.{h,m}'
   s.frameworks   = ['CoreImage', 'AVFoundation']

--- a/RSBarcodes/RSCodeGenerator.m
+++ b/RSBarcodes/RSCodeGenerator.m
@@ -60,6 +60,8 @@ NSString * const DIGITS_STRING = @"0123456789";
     UIGraphicsBeginImageContextWithOptions(size, YES, 0);
     CGContextRef context = UIGraphicsGetCurrentContext();
     
+    CGContextSetShouldAntialias(context, false);
+    
     [[UIColor whiteColor] setFill];
     [[UIColor blackColor] setStroke];
     

--- a/RSBarcodes/RSScannerViewController.h
+++ b/RSBarcodes/RSScannerViewController.h
@@ -6,9 +6,13 @@
 //  Copyright (c) 2013 P.D.Q. All rights reserved.
 //
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
-
 #import <UIKit/UIKit.h>
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < 60000
+
+extern NSString *const AVMetadataObjectTypeFace;
+
+#endif
 
 @class RSCornersView;
 
@@ -33,5 +37,3 @@ typedef void (^RSTapGestureHandler)(CGPoint tapPoint);
 @property (nonatomic) BOOL isFocusMarkVisible;   // Default is YES
 
 @end
-
-#endif

--- a/RSBarcodes/RSScannerViewController.h
+++ b/RSBarcodes/RSScannerViewController.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2013 P.D.Q. All rights reserved.
 //
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
+
 #import <UIKit/UIKit.h>
 
 @class RSCornersView;
@@ -31,3 +33,5 @@ typedef void (^RSTapGestureHandler)(CGPoint tapPoint);
 @property (nonatomic) BOOL isFocusMarkVisible;   // Default is YES
 
 @end
+
+#endif

--- a/RSBarcodes/RSScannerViewController.m
+++ b/RSBarcodes/RSScannerViewController.m
@@ -6,13 +6,17 @@
 //  Copyright (c) 2013 P.D.Q. All rights reserved.
 //
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
-
 #import "RSScannerViewController.h"
 
 #import "RSCornersView.h"
 
 #import <AVFoundation/AVFoundation.h>
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < 60000
+
+NSString *const AVMetadataObjectTypeFace = @"face";
+
+#endif
 
 @interface RSScannerViewController () <AVCaptureMetadataOutputObjectsDelegate>
 
@@ -230,5 +234,3 @@
 }
 
 @end
-
-#endif

--- a/RSBarcodes/RSScannerViewController.m
+++ b/RSBarcodes/RSScannerViewController.m
@@ -6,6 +6,8 @@
 //  Copyright (c) 2013 P.D.Q. All rights reserved.
 //
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
+
 #import "RSScannerViewController.h"
 
 #import "RSCornersView.h"
@@ -228,3 +230,5 @@
 }
 
 @end
+
+#endif

--- a/RSBarcodes/RSUnifiedCodeGenerator.h
+++ b/RSBarcodes/RSUnifiedCodeGenerator.h
@@ -10,6 +10,21 @@
 
 #import "RSCodeGenerator.h"
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < 70000
+
+extern NSString *const AVMetadataObjectTypeUPCECode;
+extern NSString *const AVMetadataObjectTypeCode39Code;
+extern NSString *const AVMetadataObjectTypeCode39Mod43Code;
+extern NSString *const AVMetadataObjectTypeEAN13Code;
+extern NSString *const AVMetadataObjectTypeEAN8Code;
+extern NSString *const AVMetadataObjectTypeCode93Code;
+extern NSString *const AVMetadataObjectTypeCode128Code;
+extern NSString *const AVMetadataObjectTypePDF417Code;
+extern NSString *const AVMetadataObjectTypeQRCode;
+extern NSString *const AVMetadataObjectTypeAztecCode;
+
+#endif
+
 @interface RSUnifiedCodeGenerator : NSObject <RSCodeGenerator>
 
 + (instancetype)codeGen;

--- a/RSBarcodes/RSUnifiedCodeGenerator.m
+++ b/RSBarcodes/RSUnifiedCodeGenerator.m
@@ -63,7 +63,9 @@ NSString *const AVMetadataObjectTypeAztecCode = @"org.iso.Aztec";
     if ([type isEqualToString:AVMetadataObjectTypeQRCode]
         || [type isEqualToString:AVMetadataObjectTypePDF417Code]
         || [type isEqualToString:AVMetadataObjectTypeAztecCode]) {
-        return genCode(contents, getFilterName(type));
+        if (([[[UIDevice currentDevice] systemVersion] compare:@"6.0" options:NSNumericSearch] != NSOrderedAscending)) {
+            return genCode(contents, getFilterName(type));
+        }
     }
     
     id<RSCodeGenerator> codeGen = nil;

--- a/RSBarcodes/RSUnifiedCodeGenerator.m
+++ b/RSBarcodes/RSUnifiedCodeGenerator.m
@@ -28,6 +28,22 @@
 
 #import "RSISSN13Generator.h"
 
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < 70000
+
+NSString *const AVMetadataObjectTypeUPCECode = @"org.gs1.UPC-E";
+NSString *const AVMetadataObjectTypeCode39Code = @"org.iso.Code39";
+NSString *const AVMetadataObjectTypeCode39Mod43Code = @"org.iso.Code39Mod43";
+NSString *const AVMetadataObjectTypeEAN13Code = @"org.gs1.EAN-13";
+NSString *const AVMetadataObjectTypeEAN8Code = @"org.gs1.EAN-8";
+NSString *const AVMetadataObjectTypeCode93Code = @"com.intermec.Code93";
+NSString *const AVMetadataObjectTypeCode128Code = @"org.iso.Code128";
+NSString *const AVMetadataObjectTypePDF417Code = @"";
+NSString *const AVMetadataObjectTypeQRCode = @"org.iso.PDF417";
+NSString *const AVMetadataObjectTypeAztecCode = @"org.iso.Aztec";
+
+#endif
+
 @implementation RSUnifiedCodeGenerator
 
 + (instancetype)codeGen

--- a/RSBarcodes/RSUnifiedCodeGenerator.m
+++ b/RSBarcodes/RSUnifiedCodeGenerator.m
@@ -38,8 +38,8 @@ NSString *const AVMetadataObjectTypeEAN13Code = @"org.gs1.EAN-13";
 NSString *const AVMetadataObjectTypeEAN8Code = @"org.gs1.EAN-8";
 NSString *const AVMetadataObjectTypeCode93Code = @"com.intermec.Code93";
 NSString *const AVMetadataObjectTypeCode128Code = @"org.iso.Code128";
-NSString *const AVMetadataObjectTypePDF417Code = @"";
-NSString *const AVMetadataObjectTypeQRCode = @"org.iso.PDF417";
+NSString *const AVMetadataObjectTypePDF417Code = @"org.iso.PDF417";
+NSString *const AVMetadataObjectTypeQRCode = @"org.iso.QRCode";
 NSString *const AVMetadataObjectTypeAztecCode = @"org.iso.Aztec";
 
 #endif


### PR DESCRIPTION
Hi R0CKSTAR,

I needed to support generation of barcodes on iOS 5/6, so I made some some changes and tested it on iOS 5.1, 6 and 7.

Regards,

André
