### PR TITLE
Fix check for isFocusPointOfInterestSupported to correctly handle iPod Touch 5th Gen

### DIFF
--- a/RSBarcodes/RSScannerViewController.m
+++ b/RSBarcodes/RSScannerViewController.m
@@ -48,8 +48,8 @@ NSString *const AVMetadataObjectTypeFace = @"face";
     CGPoint focusPoint= CGPointMake(tapPoint.x / self.view.bounds.size.width, tapPoint.y / self.view.bounds.size.height);
     
     if (!self.device
-        && ![self.device isFocusPointOfInterestSupported]
-        && ![self.device isFocusModeSupported:AVCaptureFocusModeAutoFocus]) {
+        || ![self.device isFocusPointOfInterestSupported]
+        || ![self.device isFocusModeSupported:AVCaptureFocusModeAutoFocus]) {
         return;
     } else if ([self.device lockForConfiguration:nil]) {
         [self.device setFocusPointOfInterest:focusPoint];


### PR DESCRIPTION
The 5th Gen iPod Touch supports `AVCaptureFocusModeAutoFocus` but not `isFocusPointOfInterestSupported`. It looks like the original check was incorrect: it should not proceed unless the device supports both `AVCaptureFocusModeAutoFocus` _and_ `isFocusPointOfInterestSupported`, rather then aborting only if the device supports neither.
