### PR TITLE
Scaled up 2D codes to prevent blurriness

### DIFF
--- a/RSBarcodes/RSCodeGenerator.h
+++ b/RSBarcodes/RSCodeGenerator.h
@@ -113,7 +113,8 @@ static inline UIImage *genCode(NSString *contents, NSString *filterName) {
     NSData *data = [contents dataUsingEncoding:NSUTF8StringEncoding];
     [filter setValue:data forKey:@"inputMessage"];
     
-    CIImage *outputImage = [filter outputImage];
+    CGAffineTransform scale = CGAffineTransformMakeScale(15.0f, 15.0f);
+    CIImage *outputImage = [[filter outputImage] imageByApplyingTransform:scale];
     CIContext *context = [CIContext contextWithOptions:nil];
     CGImageRef cgImage =
     [context createCGImage:outputImage fromRect:[outputImage extent]];


### PR DESCRIPTION
If you generate a QR code with a short content string, the resulting image will have small dimensions.

For instance, I generated a code using a 20 character string as content, and the image returned was 27x27 pixels. I wanted to display it on a 300x300 view, so it ended up very blurred.

To prevent it, all the 2D codes are now scaled by a factor of 15x. This way, the image will be downscaled when shown, and the quality will be preserved.

Here's a before and after comparison: http://cl.ly/image/3W0k2F2k181F
