### PR TITLE
Optionally set fill and stroke color on code generators

### DIFF
--- a/RSBarcodes/RSCodeGenerator.h
+++ b/RSBarcodes/RSCodeGenerator.h
@@ -23,6 +23,12 @@
 - (UIImage *)genCodeWithContents:(NSString *)contents
    machineReadableCodeObjectType:(NSString *)type;
 
+/** The fill (background) color of the generated barcode. */
+@property (nonatomic, strong) UIColor *fillColor;
+
+/** The stroke color of the generated barcode. */
+@property (nonatomic, strong) UIColor *strokeColor;
+
 @end
 
 /**

--- a/RSBarcodes/RSCodeGenerator.m
+++ b/RSBarcodes/RSCodeGenerator.m
@@ -10,6 +10,8 @@
 
 @implementation RSAbstractCodeGenerator
 
+@synthesize strokeColor = _strokeColor, fillColor = _fillColor;
+
 NSString *const DIGITS_STRING = @"0123456789";
 
 - (BOOL)isContentsValid:(NSString *)contents {
@@ -55,13 +57,21 @@ NSString *const DIGITS_STRING = @"0123456789";
     // Left & right spacing = 2
     // Height               = 28
     CGSize size = CGSizeMake(code.length + 4, 28);
-    UIGraphicsBeginImageContextWithOptions(size, YES, 0);
+    UIGraphicsBeginImageContextWithOptions(size, NO, 0);
     CGContextRef context = UIGraphicsGetCurrentContext();
     
     CGContextSetShouldAntialias(context, false);
     
-    [[UIColor whiteColor] setFill];
-    [[UIColor blackColor] setStroke];
+    if (!self.fillColor) {
+        self.fillColor = [UIColor whiteColor];
+    }
+    
+    if (!self.strokeColor) {
+        self.strokeColor = [UIColor blackColor];
+    }
+    
+    [self.fillColor setFill];
+    [self.strokeColor setStroke];
     
     CGContextFillRect(context, CGRectMake(0, 0, size.width, size.height));
     CGContextSetLineWidth(context, 1);

--- a/RSBarcodes/RSUnifiedCodeGenerator.m
+++ b/RSBarcodes/RSUnifiedCodeGenerator.m
@@ -47,6 +47,8 @@ NSString *const AVMetadataObjectTypeAztecCode = @"org.iso.Aztec";
 
 @implementation RSUnifiedCodeGenerator
 
+@synthesize strokeColor = _strokeColor, fillColor = _fillColor;
+
 + (instancetype)codeGen {
     static RSUnifiedCodeGenerator *codeGen = nil;
     static dispatch_once_t onceToken;
@@ -104,6 +106,9 @@ NSString *const AVMetadataObjectTypeAztecCode = @"org.iso.Aztec";
     }
     
     if (codeGen) {
+        codeGen.fillColor = self.fillColor;
+        codeGen.strokeColor = self.strokeColor;
+        
         return [codeGen genCodeWithContents:contents
               machineReadableCodeObjectType:type];
     } else {


### PR DESCRIPTION
In the app me and my team is developing, we needed to set the background color of the generated barcode image to match the background color of the background view (a very light gray color).

We solved this by setting the fill color of the generated image to `[UIColor clearColor]` so that the barcode is just black lines on whatever background it happens to be on. This is also the reason why the generated image is not `opaque` anymore.