### PR TITLE
RSScannerViewController not respecting stopOnFirst

### DIFF
--- a/RSBarcodes/RSScannerViewController.m
+++ b/RSBarcodes/RSScannerViewController.m
@@ -378,9 +378,6 @@ didOutputMetadataObjects:(NSArray *)metadataObjects
         self.barcodesHandler([NSArray arrayWithArray:barcodeObjects]);
     }
     
-    if (self.stopOnFirst) {
-        [self startRunning];
-    }
 }
 
 #pragma mark - Public


### PR DESCRIPTION
After the captureOutput delegate method is finished executing, the scanner is restarted if stopOnFirst is set to true. This behavior was causing the delegate method to fire again in some scenarios, resulting in the barcodesScanner block being executed twice regardless of the setting.