### PR TITLE
Fix video layer size on view size change

### DIFF
--- a/RSBarcodes/RSScannerViewController.m
+++ b/RSBarcodes/RSScannerViewController.m
@@ -265,6 +265,7 @@ NSString *const AVMetadataObjectTypeFace = @"face";
     if (self.layer.connection.supportsVideoOrientation && source != target) {
         self.layer.connection.videoOrientation = target;
     }
+    self.layer.frame = self.view.bounds;
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {


### PR DESCRIPTION
Fixes an issue I have when embedding the view controller in another one (using container views in storyboard).

The controller's view frame changes between init and an auto layout pass, so we need to update the video layer's frame too.